### PR TITLE
修改以下bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # SeaweedFS Client For Java
 
+# latest readme
+项目frok自[SeaweedFS Client For Java](https://github.com/Shuyun123/seaweedfs-java-client.git).
+修复了以下bug:
+1.当weedfs运行在docker中时，自动更新为docker container虚拟地址的情况
+2.在返回值中加入了文件的具体链接。
+
+maven 版本暂未更新。
+
+## Original Content
+
 [![Maven Central](http://img.shields.io/badge/maven_central-0.0.1.RELEASE-brightgreen.svg)](https://search.maven.org/#artifactdetails%7Corg.lokra.seaweedfs%7Cseaweedfs-client%7C0.7.3.RELEASE%7Cjar)
 [![GitHub Release](http://img.shields.io/badge/Release-0.0.1.RELEASE-brightgreen.svg)](https://github.com/lokra-platform/seaweedfs-client/releases/tag/0.7.3.RELEASE)
 [![Apache license](https://img.shields.io/badge/license-Apache-blue.svg)](http://opensource.org/licenses/Apache)
 
 
 项目更改自[weed-client](https://github.com/lokra/weed-client)，修复了一下作者原来的部分bug，然后重新打包了。
+
 
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 # latest readme
 项目frok自[SeaweedFS Client For Java](https://github.com/Shuyun123/seaweedfs-java-client.git).
 修复了以下bug:
-1.当weedfs运行在docker中时，自动更新为docker container虚拟地址的情况
+1.判定leader之前先判断IsLeader，避免当weedfs运行在docker中时，自动更新为docker container虚拟地址的情况
 2.在返回值中加入了文件的具体链接。
+3.使用HttpClientBuilder.create().build()，防止超时。
 
 maven 版本暂未更新。
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>net.anumbrella.seaweedfs</groupId>
   <artifactId>seaweedfs-java-client</artifactId>
-  <version>0.0.1.RELEASE</version>
+  <version>0.0.2.RELEASE</version>
   <packaging>jar</packaging>
 
   <name>seaweedfs-java-client</name>

--- a/src/main/java/net/anumbrella/seaweedfs/core/Connection.java
+++ b/src/main/java/net/anumbrella/seaweedfs/core/Connection.java
@@ -24,6 +24,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClients;

--- a/src/main/java/net/anumbrella/seaweedfs/core/file/FileHandleStatus.java
+++ b/src/main/java/net/anumbrella/seaweedfs/core/file/FileHandleStatus.java
@@ -9,6 +9,8 @@ public class FileHandleStatus implements Serializable{
     private String fileName;
     private String contentType;
     private long size;
+    private String fileUrl;
+
 
     public FileHandleStatus(String fileId, long lastModified, String fileName, String contentType, long size) {
         this.fileId = fileId;
@@ -21,6 +23,12 @@ public class FileHandleStatus implements Serializable{
     public FileHandleStatus(String fileId, long size) {
         this.fileId = fileId;
         this.size = size;
+    }
+    
+    public FileHandleStatus(String fileId, long size,String publicUrl) {
+        this.fileId = fileId;
+        this.size = size;
+        this.fileUrl = publicUrl+"/"+fileId;
     }
 
     public String getFileId() {
@@ -41,6 +49,14 @@ public class FileHandleStatus implements Serializable{
 
     public String getContentType() {
         return contentType;
+    }
+    
+    public String getFileUrl() {
+        return fileUrl;
+    }
+
+    public void setFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
     }
 
     @Override


### PR DESCRIPTION
1.判定leader之前先判断IsLeader，避免当weedfs运行在docker中时，自动更新为docker container虚拟地址的情况
2.在返回值中加入了文件的具体链接。
3.使用HttpClientBuilder.create().build()，防止超时。